### PR TITLE
Trim long strings for the dataset field over 256 bytes

### DIFF
--- a/dataset/dataset.go
+++ b/dataset/dataset.go
@@ -16,7 +16,7 @@ var (
 	datasetNameRegexp = regexp.MustCompile(`[^0-9a-z._\- ]+`)
 )
 
-const MaxStringLength = 256
+const maxFieldValueByteLength = 256
 
 type BuilderConfig struct {
 	Report           *servicetitan.Report
@@ -77,10 +77,8 @@ func (d *DatasetBuilder) BuildData() geckoboard.Data {
 
 				switch nval := val.(type) {
 				case string:
-					if len(nval) > MaxStringLength {
-						// Support single and multi-byte chars
-						runeSlice := []rune(nval)
-						nval = string(runeSlice[:MaxStringLength])
+					if len(nval) > maxFieldValueByteLength {
+						nval = nval[:maxFieldValueByteLength]
 					}
 					gr[name] = nval
 				case bool:

--- a/dataset/dataset.go
+++ b/dataset/dataset.go
@@ -75,6 +75,12 @@ func (d *DatasetBuilder) BuildData() geckoboard.Data {
 
 				switch nval := val.(type) {
 				case string:
+					// Geckoboard datasets string fields only support 256 chars
+					if len(nval) > 256 {
+						// Support single and multi-byte chars
+						runeSlice := []rune(nval)
+						nval = string(runeSlice[:250])
+					}
 					gr[name] = nval
 				case bool:
 					gr[name] = strings.ToUpper(strconv.FormatBool(nval))

--- a/dataset/dataset.go
+++ b/dataset/dataset.go
@@ -16,6 +16,8 @@ var (
 	datasetNameRegexp = regexp.MustCompile(`[^0-9a-z._\- ]+`)
 )
 
+const MaxStringLength = 256
+
 type BuilderConfig struct {
 	Report           *servicetitan.Report
 	Data             *servicetitan.ReportData
@@ -75,11 +77,10 @@ func (d *DatasetBuilder) BuildData() geckoboard.Data {
 
 				switch nval := val.(type) {
 				case string:
-					// Geckoboard datasets string fields only support 256 chars
-					if len(nval) > 256 {
+					if len(nval) > MaxStringLength {
 						// Support single and multi-byte chars
 						runeSlice := []rune(nval)
-						nval = string(runeSlice[:250])
+						nval = string(runeSlice[:MaxStringLength])
 					}
 					gr[name] = nval
 				case bool:

--- a/dataset/dataset_test.go
+++ b/dataset/dataset_test.go
@@ -3,6 +3,7 @@ package dataset
 import (
 	"servicetitan-to-dataset/config"
 	"servicetitan-to-dataset/servicetitan"
+	"strings"
 	"testing"
 
 	"github.com/jnormington/geckoboard"
@@ -38,6 +39,7 @@ func TestDatasetBuilder_BuildSchema(t *testing.T) {
 				"number_of_jobs":  {Type: "number", Optional: true, Name: "Completed Jobs"},
 				"completion_rate": {Type: "percentage", Name: "Completion rate", Optional: true}, // type override in config
 				"created_on":      {Type: "datetime", Optional: true, Name: "Created on"},
+				"tags":            {Type: "string", Optional: true, Name: "Tags"},
 			},
 			UniqueBy: []string{"name"},
 		}
@@ -95,6 +97,7 @@ func TestDatasetBuilder_BuildData(t *testing.T) {
 				"number_of_jobs":  5,
 				"completion_rate": 0.12,
 				"created_on":      "2023-10-13T00:00:00-05:00",
+				"tags":            strings.Repeat("a", 256),
 			},
 			map[string]interface{}{
 				"active":          "TRUE",
@@ -103,6 +106,7 @@ func TestDatasetBuilder_BuildData(t *testing.T) {
 				"number_of_jobs":  9,
 				"completion_rate": 0.24,
 				"created_on":      "2023-10-13T00:00:00-05:00Z",
+				"tags":            strings.Repeat("b", 100),
 			},
 			map[string]interface{}{
 				"active":          "FALSE",
@@ -111,6 +115,7 @@ func TestDatasetBuilder_BuildData(t *testing.T) {
 				"number_of_jobs":  15,
 				"completion_rate": 0.87,
 				"created_on":      "2023-10-13T00:00:00-05:00",
+				"tags":            strings.Repeat("界", 256),
 			},
 		})
 	})
@@ -128,6 +133,7 @@ func buildConfig() BuilderConfig {
 				{Name: "Completed on", Label: "Completed date", Type: "Date"},
 				{Name: "Completion rate", Label: "Completion rate", Type: "Number"},
 				{Name: "Created on", Label: "Created on", Type: "Datetime"},
+				{Name: "Tags", Label: "Tags", Type: "String"},
 			},
 			Parameters: []servicetitan.ReportParameter{
 				{Name: "From", Label: "From", DataType: "Date", IsRequired: true},
@@ -141,9 +147,9 @@ func buildConfig() BuilderConfig {
 		},
 		Data: &servicetitan.ReportData{
 			Data: []interface{}{
-				[]interface{}{"John Smith", 5, true, "2021-10-13", 0.12, "2023-10-13T00:00:00-05:00"},
-				[]interface{}{"Jane Doe", 9, true, "2021-10-13", 0.24, "2023-10-13T00:00:00-05:00Z"},
-				[]interface{}{"Hilary", 15, false, "2021-10-13", 0.87, "2023-10-13T00:00:00-05:00"},
+				[]interface{}{"John Smith", 5, true, "2021-10-13", 0.12, "2023-10-13T00:00:00-05:00", strings.Repeat("a", 300)},
+				[]interface{}{"Jane Doe", 9, true, "2021-10-13", 0.24, "2023-10-13T00:00:00-05:00Z", strings.Repeat("b", 100)},
+				[]interface{}{"Hilary", 15, false, "2021-10-13", 0.87, "2023-10-13T00:00:00-05:00", strings.Repeat("界", 300)},
 			},
 			Fields: []servicetitan.ReportField{
 				{Name: "Name", Label: "Name", Type: "String"},
@@ -152,6 +158,7 @@ func buildConfig() BuilderConfig {
 				{Name: "Completed on", Label: "Completed date", Type: "Date"},
 				{Name: "Completion rate", Label: "Completion rate", Type: "Number"},
 				{Name: "Created on", Label: "Created on", Type: "Datetime"},
+				{Name: "Tags", Label: "Tags", Type: "String"},
 			},
 			HasMore:  false,
 			Page:     1,


### PR DESCRIPTION
Geckoboard Datasets string field type only supports 256 characters. Certain ServiceTitan fields (such as tags) produce strings over 256 characters.

